### PR TITLE
update aioredis from default redis

### DIFF
--- a/example/discord_cog/redis/cogs/login.py
+++ b/example/discord_cog/redis/cogs/login.py
@@ -1,5 +1,5 @@
 import discord
-import aioredis
+from redis import asyncio as aioredis
 import json
 
 from discord import WebhookMessage, app_commands


### PR DESCRIPTION
aioredis is under Redis officially which is maintained
and aioredis does not work in python 3.11